### PR TITLE
Factual corrections & wording fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@
 carpentry: "swc"
 
 # Overall title for pages.
-title: "Introduction to Using Shell in a High-Performance Computing Cluster"
+title: "Introduction to Using the Shell in a High-Performance Computing Context"
 
 # Life cycle stage of the lesson
 # possible values: "pre-alpha", "alpha", "beta", "stable"

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@
 carpentry: "swc"
 
 # Overall title for pages.
-title: "Introduction to using the shell in a High-Performance Computing context"
+title: "Introduction to Using Shell in a High-Performance Computing Cluster"
 
 # Life cycle stage of the lesson
 # possible values: "pre-alpha", "alpha", "beta", "stable"

--- a/_episodes/00-hpc-intro.md
+++ b/_episodes/00-hpc-intro.md
@@ -11,9 +11,9 @@ objectives:
 keypoints:
 - "High Performance Computing (HPC) typically involves connecting to very large computing systems
   elsewhere in the world."
-- "These other systems can be used to do work that would either be impossible or much slower or
+- "These HPC systems can be used to do work that would either be impossible or much slower or
   smaller systems."
-- "The standard method of interacting with such systems is via a command line interface called
+- "The standard method of interacting with such systems is via a command line interface such as
   Bash."
 ---
 

--- a/_episodes/01-connecting.md
+++ b/_episodes/01-connecting.md
@@ -88,10 +88,10 @@ enter or clicking the "Open" button should begin the connection process.
 If this works you will see a terminal window open that prompts you for a username through the "login
 as:" prompt and then for a password. If both of these are passed correctly then you will be given
 access to the system and will see a message saying so within the terminal. If you need to escape the
-authentication process you can hold the control/Ctrl key and press the c key to exit and start
-again.
+authentication process you can hold the Control (<kbd>Ctrl</kbd>) key and press the <kbd>c</kbd> key
+to exit and start again.
 
-Note that you may want to paste in your password rather than typing it. Use control/Ctrl plus a
+Note that you may want to paste in your password rather than typing it. Use <kbd>Ctrl</kbd> plus a
 right-click of the mouse to paste content from the clipboard to the PuTTY terminal.
 
 For those logging in with PuTTY it would likely be best to cover the terminal basics already
@@ -100,7 +100,7 @@ mentioned above before moving on to navigating the remote system.
 ## Logging onto the system
 
 With all of this in mind, let's connect to a remote HPC system. In this workshop, we will connect to
-{{ site.workshop_host }} - an HPC system located at the {{ site.workshop_host_location}}. Although it's unlikely
+{{ site.workshop_host }} --- an HPC system located at the {{ site.workshop_host_location}}. Although it's unlikely
 that every system will be exactly like {{ site.workshop_host }}, it's a very good example of what you can expect from
 an HPC installation. To connect to our example computer, we will use SSH (if you are using
 PuTTY, see above).
@@ -141,7 +141,7 @@ adopt the following convention:
 - `{{ site.workshop_host_prompt }}` when the command is to be entered on a terminal connected to the remote system
 - `$` when it really doesn't matter which system the terminal is connected to.
 
-> ## Being Certain Which System your Terminal is connected to
+> ## Being Certain Which System your Terminal is Connected to
 >
 > If you ever need to be certain which system a terminal you are using is connected to then use the
 > following command: `$ hostname`.

--- a/_episodes/01-connecting.md
+++ b/_episodes/01-connecting.md
@@ -35,8 +35,9 @@ but a very fast way is to use the terminal shortcut key sequence: Ctrl+Alt+T.
 
 ### Mac
 
-Macs have had a terminal built in since the first version of OSX since it is built on a Linux
-flavour known as BSD (Berkeley Systems Designs). The terminal can be quickly opened through the use
+Macs have had a terminal built in since the first version of OS X since it is
+built on a UNIX-like operating system, leveraging many parts from BSD (Berkeley Systems Designs).
+The terminal can be quickly opened through the use
 of the Searchlight tool. Hold down the command key and press the spacebar. In the search bar that
 shows up type "terminal", choose the terminal app from the list of results (it will look like a
 tiny, black computer screen) and you will be presented with a terminal window. Alternatively, you

--- a/_episodes/01-connecting.md
+++ b/_episodes/01-connecting.md
@@ -141,13 +141,13 @@ adopt the following convention:
 - `{{ site.workshop_host_prompt }}` when the command is to be entered on a terminal connected to the remote system
 - `$` when it really doesn't matter which system the terminal is connected to.
 
-> ## Being Certain Which System your Terminal is Connected to
+> ## Being certain which system your terminal is connected to
 >
 > If you ever need to be certain which system a terminal you are using is connected to then use the
 > following command: `$ hostname`.
 {: .callout}
 
-> ## Keep Two Terminal Windows Open
+> ## Keep two terminal windows open
 >
 > It is strongly recommended that you have two terminals open, one connected to the local system and
 > one connected to the remote system, that you can switch back and forth between. If you only use

--- a/_episodes/01-connecting.md
+++ b/_episodes/01-connecting.md
@@ -57,15 +57,15 @@ from [mobatek.net](https://mobaxterm.mobatek.net/download-home-edition.html). If
 you will note that there are two editions of the home version available: Portable and Installer. The
 portable edition puts all MobaXterm content in a folder on the desktop (or anywhere else you would
 like it) so that it is easy add plug-ins or remove the software. The installer edition adds
-MobaXterm to your Windows installation as any other program you might install. If you are not sure
-that you will continue to use MobaXterm in the future you are likely best to choose the portable
-edition.
+MobaXterm to your Windows installation and menu as any other program you might install.
+If you are not sure that you will continue to use MobaXterm in the future, the portable edition
+is likely the best choice for you.
 
 Download the version that you would like to use and install it as you would any other software on
 your Windows installation. Once the software is installed you can run it by either opening the
-folder installed with the portable edition and double-clicking on the file named
-*MobaXterm_Personal_10.2* or, if the installer edition was used, finding the executable through
-either the start menu or the Windows search option.
+folder installed with the portable edition and double-clicking on the executable file named
+`MobaXterm_Personal_11.1` (your version number may vary) or, if the installer edition was used,
+finding the executable through either the start menu or the Windows search option.
 
 Once the MobaXterm window is open you should see a large button in the middle of that window with
 the text "Start Local Terminal". Click this button and you will have a terminal window at your

--- a/_episodes/01-connecting.md
+++ b/_episodes/01-connecting.md
@@ -100,7 +100,7 @@ mentioned above before moving on to navigating the remote system.
 ## Logging onto the system
 
 With all of this in mind, let's connect to a remote HPC system. In this workshop, we will connect to
-{{ site.workshop_host }} --- an HPC system located at the {{ site.workshop_host_location}}. Although it's unlikely
+{{ site.workshop_host }} --- an HPC system located at the {{ site.workshop_host_location }}. Although it's unlikely
 that every system will be exactly like {{ site.workshop_host }}, it's a very good example of what you can expect from
 an HPC installation. To connect to our example computer, we will use SSH (if you are using
 PuTTY, see above).

--- a/_episodes/03-files.md
+++ b/_episodes/03-files.md
@@ -157,9 +157,11 @@ draft.txt  files
 ```
 {: .output}
 
-## Moving and copying files
 
-To practice moving files, we will move `draft.txt` to that directory with `mv` (move). `mv`'s syntax works for both files and directories `mv <file/directory> <path to new location>`
+## Moving, Renaming, Copying Files
+
+**Moving**---We will move `draft.txt` to the `files` directory with `mv` ("move") command.
+The same syntax works for both files and directories: `mv <file/directory> <new-location>`
 
 ```
 $ mv draft.txt files
@@ -172,10 +174,9 @@ draft.txt
 ```
 {: .output}
 
-`draft.txt` isn't a very descriptive name. How do we go about changing it?
-
-It turns out that the way to rename files and folders is with `mv` again. Although this may not seem
-intuitive at first, think of it as moving a file to be stored under a different name. The syntax is
+**Renaming**---`draft.txt` isn't a very descriptive name. How do we go about changing it?
+It turns out that `mv` is also used to rename files and directories. Although this may not seem
+intuitive at first, think of it as *moving* a file to be stored under a different name. The syntax is
 quite similar to moving files: `mv oldName newName`.
 
 ```
@@ -198,8 +199,8 @@ newname.testfile
 > for instance.
 {: .callout}
 
-What if we want to copy a file, instead of simply renaming or moving it? Use `cp` (an abbreviated
-name for "copy"). This command has to different uses that work in the same way as `mv`:
+**Copying**---What if we want to copy a file, instead of simply renaming or moving it?
+Use `cp` command (an abbreviated name for "copy"). This command has to different uses that work in the same way as `mv`:
 
 - Copy to same directory (copied file is renamed): `cp file newFilename`
 - Copy to other directory (copied file retains original name): `cp file directory`

--- a/_episodes/03-files.md
+++ b/_episodes/03-files.md
@@ -3,13 +3,20 @@ title: Writing and reading files
 teaching: 30
 exercises: 15
 questions:
-- "How do I create/move/delete files?"
-- "How do I edit files?"
+- "How do I create/edit text files?"
+- "How do I move/copy/delete files?"
 objectives:
 - "Learn to use the `nano` text editor."
 - "Understand how to move, create, and delete files."
 keypoints:
-- "File extensions are entirely arbitrary."
+- "Use `nano` to create or edit text files from a terminal."
+- "`cat file1 [file2 ...]` prints the contents of one or more files to terminal."
+- "`mv old dir` moves a file or directory to another directory `dir`."
+- "`mv old new` renames a file or directory."
+- "`cp old new` copies a file."
+- "`cp old dir` copies a file to another directory `dir`."
+- "`rm path` deletes (removes) a file."
+- "File extensions are entirely arbitrary on UNIX systems."
 ---
 
 Now that we know how to move around and look at things, let's learn how to read, write, and handle

--- a/_episodes/03-files.md
+++ b/_episodes/03-files.md
@@ -29,13 +29,44 @@ $ cd hpc-test
 ```
 {: .language-bash}
 
+
+## Creating and Editing Text Files
+
+When working on an HPC system, we will frequently need to create or edit text files.
+Text is one of the simplest computer file formats, defined as a simple sequence of text lines.
+
 What if we want to make a file? There are a few ways of doing this, the easiest of which is simply
 using a text editor. For this lesson, we are going to us `nano`, since it's more intuitive than many
 other terminal text editors.
 
-To use `nano` on a file, type `nano filename`. If the file does not exist, it will be
-created. `^O` (Ctrl + O) saves the file, and `^X` quits. If you have not saved your file upon trying
-to quit, it will ask you if you want to save.
+To create or edit a file, type `nano filename`, on the terminal, where `filename` is the name of the
+file.  If the file does not already exist, it will be created.
+Let's make a new file now, type whatever you want in it, and save it.
+
+```
+$ nano test.txt
+```
+{: .language-bash}
+
+![Nano in action]({{ site.url }}{{ site.baseurl }}/fig/nano-screenshot.png)
+
+Nano defines a number of *shortcut keys* (prefixed by the <kbd>Control</kbd> or <kbd>Ctrl</kbd> key)
+to perform actions such as saving the file or exiting the editor.
+Here are the shortcut keys for a few common actions:
+
+* <kbd>Ctrl</kbd>+<kbd>O</kbd> --- save the file (into a current name or a new name).
+
+* <kbd>Ctrl</kbd>+<kbd>X</kbd> --- exit the editor.
+  If you have not saved your file upon exiting, `nano` will ask you if you want to save.
+
+* <kbd>Ctrl</kbd>+<kbd>K</kbd> --- cut ("kill") a text line.
+  This command deletes a line and saves it on a clipboard.
+  If repeated multiple times without any interruption (key typing or cursor movement),
+  it will cut a chunk of text lines.
+
+* <kbd>Ctrl</kbd>+<kbd>U</kbd> --- paste the cut text line (or lines).
+  This command can be repeated to paste the same text elsewhere.
+
 
 > ## Using `vim` as a text editor
 >
@@ -49,20 +80,11 @@ to quit, it will ask you if you want to save.
 > In insert mode, you can type more or less normally. In command mode there are a few commands you
 > should be aware of:
 >
-> * `:q!` - quit, without saving
-> * `:wq` - save and quit
-> * `dd` - cut/delete a line
-> * `y` - paste a line
+> * `:q!` --- quit, without saving
+> * `:wq` --- save and quit
+> * `dd` --- cut/delete a line
+> * `y` --- paste a line
 {: .callout}
-
-Let's make a new file now, type whatever you want in it, and save it.
-
-```
-nano test.txt
-```
-{: .language-bash}
-
-![Nano in action]({{ site.url }}{{ site.baseurl }}/fig/nano-screenshot.png)
 
 Do a quick check to confirm our file was created.
 

--- a/_episodes/03-files.md
+++ b/_episodes/03-files.md
@@ -39,7 +39,7 @@ What if we want to make a file? There are a few ways of doing this, the easiest 
 using a text editor. For this lesson, we are going to us `nano`, since it's more intuitive than many
 other terminal text editors.
 
-To create or edit a file, type `nano filename`, on the terminal, where `filename` is the name of the
+To create or edit a file, type `nano <filename>`, on the terminal, where `<filename>` is the name of the
 file.  If the file does not already exist, it will be created.
 Let's make a new file now, type whatever you want in it, and save it.
 
@@ -98,7 +98,10 @@ draft.txt
 ```
 {: .output}
 
-Let's read our file now. There are a few different ways of doing this, one of which is
+
+## Reading Files
+
+Let's read the file we just created now. There are a few different ways of doing this, one of which is
 reading the entire file with `cat`.
 
 ```
@@ -112,9 +115,11 @@ it's "share and thrive".
 ```
 {: .output}
 
-Although `cat` may not seem like an intuitive command with which to open files, it stands for
-"concatenate"- giving it multiple arguments will print out one file followed by the contents of the
-next, and so on.
+By default, `cat` prints out the content of the given file.
+Although `cat` may not seem like an intuitive command with which to read files, it stands for
+"concatenate". Giving it multiple file names will print out the contents of the input files in the order
+specified in the `cat`'s invocation.
+For example,
 
 ```
 $ cat draft.txt draft.txt
@@ -128,6 +133,13 @@ It's not "publish or perish" any more,
 it's "share and thrive".
 ```
 {: .output}
+
+> ## Reading Multiple Text Files
+>
+> Create two more files using `nano`, giving them different names such as `chap1.txt` and
+> `chap2.txt`. Then use a single `cat` command to read and print the contents of `draft.txt`,
+> `chap1.txt`, and `chap2.txt`.
+{: .challenge}
 
 We've successfully created a file. What about a directory? We've actually done this before, using
 `mkdir`.

--- a/_episodes/03-files.md
+++ b/_episodes/03-files.md
@@ -44,7 +44,7 @@ file.  If the file does not already exist, it will be created.
 Let's make a new file now, type whatever you want in it, and save it.
 
 ```
-$ nano test.txt
+$ nano draft.txt
 ```
 {: .language-bash}
 
@@ -94,7 +94,7 @@ $ ls
 {: .language-bash}
 
 ```
-test.txt
+draft.txt
 ```
 {: .output}
 
@@ -102,7 +102,7 @@ Let's read our file now. There are a few different ways of doing this, one of wh
 reading the entire file with `cat`.
 
 ```
-$ cat test.txt
+$ cat draft.txt
 ```
 {: .language-bash}
 
@@ -117,7 +117,7 @@ Although `cat` may not seem like an intuitive command with which to open files, 
 next, and so on.
 
 ```
-$ cat test.txt test.txt
+$ cat draft.txt draft.txt
 ```
 {: .language-bash}
 
@@ -140,27 +140,27 @@ $ ls
 
 ## Moving and copying files
 
-To practice moving files, we will move `test.txt` to that directory with `mv` (move). `mv`'s syntax works for both files and directories `mv <file/directory> <path to new location>`
+To practice moving files, we will move `draft.txt` to that directory with `mv` (move). `mv`'s syntax works for both files and directories `mv <file/directory> <path to new location>`
 
 ```
-$ mv test.txt files
+$ mv draft.txt files
 $ cd files
 $ ls
 ```
 {: .language-bash}
 ```
-test.txt
+draft.txt
 ```
 {: .output}
 
-`test.txt` isn't a very descriptive name. How do we go about changing it?
+`draft.txt` isn't a very descriptive name. How do we go about changing it?
 
 It turns out that the way to rename files and folders is with `mv` again. Although this may not seem
 intuitive at first, think of it as moving a file to be stored under a different name. The syntax is
 quite similar to moving files: `mv oldName newName`.
 
 ```
-$ mv test.txt newname.testfile
+$ mv draft.txt newname.testfile
 $ ls
 ```
 {: .language-bash}

--- a/_episodes/03-files.md
+++ b/_episodes/03-files.md
@@ -20,10 +20,12 @@ keypoints:
 ---
 
 Now that we know how to move around and look at things, let's learn how to read, write, and handle
-files! We'll start by moving back to our home directory:
+files! We'll start by moving back to our home directory and creating a scratch directory:
 
 ```
 $ cd ~
+$ mkdir hpc-test
+$ cd hpc-test
 ```
 {: .language-bash}
 

--- a/_episodes/03-files.md
+++ b/_episodes/03-files.md
@@ -141,6 +141,9 @@ it's "share and thrive".
 > `chap1.txt`, and `chap2.txt`.
 {: .challenge}
 
+
+## Creating Directory
+
 We've successfully created a file. What about a directory? We've actually done this before, using
 `mkdir`.
 
@@ -149,6 +152,10 @@ $ mkdir files
 $ ls
 ```
 {: .language-bash}
+```
+draft.txt  files
+```
+{: .output}
 
 ## Moving and copying files
 

--- a/_episodes/03-files.md
+++ b/_episodes/03-files.md
@@ -107,7 +107,8 @@ $ cat test.txt
 {: .language-bash}
 
 ```
-This is the contents of our test file.
+It's not "publish or perish" any more,
+it's "share and thrive".
 ```
 {: .output}
 
@@ -121,8 +122,10 @@ $ cat test.txt test.txt
 {: .language-bash}
 
 ```
-This is the contents of our test file.
-This is the contents of our test file.
+It's not "publish or perish" any more,
+it's "share and thrive".
+It's not "publish or perish" any more,
+it's "share and thrive".
 ```
 {: .output}
 

--- a/_episodes/03-files.md
+++ b/_episodes/03-files.md
@@ -200,7 +200,7 @@ newname.testfile
 {: .callout}
 
 **Copying**---What if we want to copy a file, instead of simply renaming or moving it?
-Use `cp` command (an abbreviated name for "copy"). This command has to different uses that work in the same way as `mv`:
+Use `cp` command (an abbreviated name for "copy"). This command has two different uses that work in the same way as `mv`:
 
 - Copy to same directory (copied file is renamed): `cp file newFilename`
 - Copy to other directory (copied file retains original name): `cp file directory`

--- a/_episodes/04-wildcards-pipes.md
+++ b/_episodes/04-wildcards-pipes.md
@@ -21,10 +21,10 @@ keypoints:
 > If you didn't get them in the last lesson, make sure to download the example files used in the
 > next few sections:
 > 
-> **Using wget** - `wget {{site.url}}{{site.baseurl}}/bash-lesson.tar.gz`
+> **Using wget** --- `wget {{site.url}}{{site.baseurl}}/files/bash-lesson.tar.gz`
 >
-> **Using a web browser** -
-> [{{site.url}}{{site.baseurl}}/bash-lesson.tar.gz]({{site.url}}{{site.baseurl}}/bash-lesson.tar.gz)
+> **Using a web browser** ---
+> [{{site.url}}{{site.baseurl}}/files/bash-lesson.tar.gz]({{site.url}}{{site.baseurl}}/files/bash-lesson.tar.gz)
 {: .testimonial}
 
 Now that we know some of the basic UNIX commands, we are going to explore some more advanced

--- a/_episodes/04-wildcards-pipes.md
+++ b/_episodes/04-wildcards-pipes.md
@@ -21,10 +21,10 @@ keypoints:
 > If you didn't get them in the last lesson, make sure to download the example files used in the
 > next few sections:
 > 
-> **Using wget** - `wget {{site.url}}{{site.baseurl}}/bash-lesson.tar.gz`
+> **Using wget** - `wget {{site.url}}{{site.baseurl}}/files/bash-lesson.tar.gz`
 >
 > **Using a web browser** -
-> [{{site.url}}{{site.baseurl}}/bash-lesson.tar.gz]({{site.url}}{{site.baseurl}}/bash-lesson.tar.gz)
+> [{{site.url}}{{site.baseurl}}/files/bash-lesson.tar.gz]({{site.url}}{{site.baseurl}}/files/bash-lesson.tar.gz)
 {: .testimonial}
 
 Now that we know some of the basic UNIX commands, we are going to explore some more advanced

--- a/_episodes/05-scripts.md
+++ b/_episodes/05-scripts.md
@@ -16,8 +16,12 @@ keypoints:
 
 We now know a lot of UNIX commands! Wouldn't it be great if we could save certain commands so that
 we could run them later or not have to type them out again? As it turns out, this is straightforward
-to do. Saving a list of commands to a file is called a "shell script". These shell scripts can be
+to do. A "shell script" is essentially a text file containing a list of UNIX commands to be
+executed in a sequential manner. These shell scripts can be
 run whenever we want, and are a great way to automate our work.
+
+
+## Writing a Script
 
 So how do we write a shell script, exactly? It turns out we can do this with a text editor.
 Start editing a file called "demo.sh" (to recap, we can do this with `nano demo.sh`). The ".sh" is

--- a/reference.md
+++ b/reference.md
@@ -6,3 +6,19 @@ permalink: /reference/
 ## Glossary
 
 FIXME
+
+
+## External References
+
+### Text Editing
+
+* [Nano editor home page](https://www.nano-editor.org/)
+
+  * [Nano tutorial](https://www.howtoforge.com/linux-nano-command/)
+
+* [VIM editor home page](https://www.vim.org/)
+
+  * Vim also has a built-in tutorial. From the bash prompt, type `vimtutor`
+    and follow the instructions.
+
+


### PR DESCRIPTION
Some points: 

* Wording fixes in 00-hpc-intro page (Reason: "bash" is just one possible command-line interface; on our cluster we use "tcsh" by default)

* Factual corrections (especially about Mac OS X)

* Tweaked instructions for MobaXTerm

* Introduced `<kbd>` key formatting